### PR TITLE
Fix wrong language syntax detection in test

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -100,8 +100,6 @@ git diff-index --cached --full-index --diff-filter=ACM $against |while read -r l
     out="red"
   elif [ "${ext}" = "go" ]; then
     cmd="gofmt -e"
-  elif [ "${she}" = "bash" ]; then
-    cmd="bash -n"
   elif [ "${she}" = "sh" ]; then
     cmd="sh -n"
   elif [ "${ext}" = "php" ] || [ "${ext}" = "ctp" ] || [ "${she}" = "php" ]; then
@@ -115,6 +113,8 @@ git diff-index --cached --full-index --diff-filter=ACM $against |while read -r l
   elif [ "${ext}" = "yaml" ] || [ "${ext}" = "yml" ]; then
     tmp="${TMPDIR:-/tmp}/${$}.${ext}"
     cmd="js-yaml ${tmp}"
+  elif [ "${she}" = "bash" ]; then
+    cmd="bash -n"
   fi
 
   if [ -n "${cmd}" ]; then


### PR DESCRIPTION
When running`make test`, the test creates a file which will be detected as a valid bash script. As the pre-commit script attempts to detect the language used in the file, it runs a small test for each language one by one, and the test for detecting bash scripts will always return true. If the detection reaches this point, the script will not go any further and files in languages such as PHP, XML, and YAML will all be linted as bash scripts.

To solve the issue, the test for detecting bash scripts has been moved to the end of the list and will only be run if all other language detection return false.